### PR TITLE
update mergeObject api call for V12+ and backward compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -7,7 +7,7 @@
   "manifestPlusVersion": "1.2.0",
   "compatibility": {
     "minimum": "10",
-    "verified": "10"
+    "verified": "12"
   },
   "authors": [
     {

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -59,7 +59,7 @@ export class ConfigApp extends FormApplication {
             top: (screen.availHeight - 489) / 4,
             left: (screen.availWidth - 516) / 4
         }
-        return mergeObject(super.defaultOptions, {
+        const selectedOptions={
             classes: ['form'],
             popOut: true,
             submitOnChange: true,
@@ -72,7 +72,13 @@ export class ConfigApp extends FormApplication {
             top: this.initialPosition.top,
             left: this.initialPosition.left,
             heigh: "auto",
-        });
+        }
+
+        if (isNewerVersion(game.version, "11")) {
+            return foundry.utils.mergeObject(super.defaultOptions, selectedOptions);
+        } else {
+            return mergeObject(super.defaultOptions, selectedOptions);
+        }
     }
 
     activateListeners(html) {


### PR DESCRIPTION
A simple fix to use the V12 foundry.utils.mergeObject helper method for newer versions.